### PR TITLE
Fix failing apt_repository task on Ubuntu 22.04 - there are no Jammy PPA releases

### DIFF
--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -27,9 +27,9 @@ jobs:
     strategy:
       matrix:
         image:
+          - geerlingguy/docker-ubuntu2204-ansible:latest
           - geerlingguy/docker-ubuntu2004-ansible:latest
           - geerlingguy/docker-ubuntu1804-ansible:latest
-          - geerlingguy/docker-ubuntu1604-ansible:latest
           - geerlingguy/docker-centos8-ansible:latest
           - geerlingguy/docker-centos7-ansible:latest
     steps:

--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -10,7 +10,7 @@ on:
       - master
 jobs:
   lint:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: checkout
         uses: actions/checkout@v3
@@ -23,7 +23,7 @@ jobs:
   test:
     needs:
       - lint
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         image:

--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -29,6 +29,7 @@ jobs:
         image:
           - registry.gitlab.com/aussielunix/ansible/molecule-containers/ubuntu:jammy
           - registry.gitlab.com/aussielunix/ansible/molecule-containers/ubuntu:focal
+          - registry.gitlab.com/aussielunix/ansible/molecule-containers/rockylinux:9
     steps:
       - name: checkout
         uses: actions/checkout@v3

--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -44,4 +44,3 @@ jobs:
           options: parallel
         env:
           MOLECULE_DOCKER_IMAGE: "${{ matrix.image }}"
-          ANSIBLE_REMOTE_TEMP: /tmp

--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -13,11 +13,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: "${{ github.repository }}"
       - name: molecule
-        uses: robertdebock/molecule-action@2.6.3
+        uses: robertdebock/molecule-action@4.0.9
         with:
           command: lint
   test:
@@ -34,11 +34,11 @@ jobs:
           - geerlingguy/docker-centos7-ansible:latest
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: "${{ github.repository }}"
       - name: molecule
-        uses: robertdebock/molecule-action@2.6.3
+        uses: robertdebock/molecule-action@4.0.9
         with:
           image: "${{ matrix.image }}"
           options: parallel

--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -27,9 +27,8 @@ jobs:
     strategy:
       matrix:
         image:
-          - geerlingguy/docker-ubuntu2204-ansible:latest
-          - geerlingguy/docker-ubuntu2004-ansible:latest
-          - geerlingguy/docker-ubuntu1804-ansible:latest
+          - registry.gitlab.com/aussielunix/ansible/molecule-containers/ubuntu:jammy
+          - registry.gitlab.com/aussielunix/ansible/molecule-containers/ubuntu:focal
     steps:
       - name: checkout
         uses: actions/checkout@v3

--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -30,8 +30,6 @@ jobs:
           - geerlingguy/docker-ubuntu2204-ansible:latest
           - geerlingguy/docker-ubuntu2004-ansible:latest
           - geerlingguy/docker-ubuntu1804-ansible:latest
-          - geerlingguy/docker-centos8-ansible:latest
-          - geerlingguy/docker-centos7-ansible:latest
     steps:
       - name: checkout
         uses: actions/checkout@v3

--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -10,7 +10,7 @@ on:
       - master
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: checkout
         uses: actions/checkout@v3
@@ -23,7 +23,7 @@ jobs:
   test:
     needs:
       - lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         image:

--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -44,3 +44,4 @@ jobs:
           options: parallel
         env:
           MOLECULE_DOCKER_IMAGE: "${{ matrix.image }}"
+          ANSIBLE_REMOTE_TEMP: /tmp

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Install and configure NGINX for acro hosting environments
 
 ## Requirements
 
-* Ubuntu 14.04+ or RedHat/CentOS 6+
+* Ubuntu 18.04+
 * Your playbook must gather facts
 
 ## Role Variables

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Install and configure NGINX for acro hosting environments
 
 ## Requirements
 
-* Ubuntu 18.04+
+* Ubuntu 18.04+ or CentOS/Red Hat/Rocky Linux 8+
 * Your playbook must gather facts
 
 ## Role Variables

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -5,6 +5,8 @@ galaxy_info:
   company: Acro Media Inc.
   license: GPLv3
   min_ansible_version: 2.0
+  role_name: nginx
+  namespace: acromedia
   platforms:
   - name: Ubuntu
     versions:

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -12,6 +12,7 @@ galaxy_info:
     versions:
       - jammy
       - focal
+      - xenial
   - name: EL
     versions: []
   galaxy_tags: []

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,7 +1,7 @@
 ---
 galaxy_info:
-  author: Matt Breden
-  description: Install NGINX on Ubuntu
+  author: Matt Breden, Dale Anderson, Chithra K
+  description: Install NGINX on Ubuntu or Red Hat
   company: Acro Media Inc.
   license: GPLv3
   min_ansible_version: 2.0
@@ -10,10 +10,12 @@ galaxy_info:
   platforms:
   - name: Ubuntu
     versions:
-      - jammy
-      - focal
-      - bionic
-  - name: EL
-    versions: []
+      - jammy   # 22.04
+      - focal   # 20.04
+      - bionic   # 18.04
+  - name: EL   # Or CentOS, or Rocky
+    versions:
+      - 8
+      - 9
   galaxy_tags: []
 dependencies: []

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,7 +1,7 @@
 ---
 galaxy_info:
   author: Matt Breden
-  description: Install Nginx on Ubuntu or RedHat/CentOS
+  description: Install NGINX on Ubuntu
   company: Acro Media Inc.
   license: GPLv3
   min_ansible_version: 2.0
@@ -10,11 +10,9 @@ galaxy_info:
   platforms:
   - name: Ubuntu
     versions:
-    - trusty
-    - xenial
-    - bionic
+      - jammy
+      - focal
   - name: EL
-    versions:
-      - 6
+    versions: []
   galaxy_tags: []
 dependencies: []

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -12,7 +12,7 @@ galaxy_info:
     versions:
       - jammy
       - focal
-      - xenial
+      - bionic
   - name: EL
     versions: []
   galaxy_tags: []

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -1,4 +1,5 @@
 ---
+role_name_check: 1
 dependency:
   name: galaxy
 driver:

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -8,6 +8,7 @@ platforms:
   - name: instance
     image: ${MOLECULE_DOCKER_IMAGE:-'geerlingguy/docker-ubuntu1804-ansible:latest'}
     # command: ${MOLECULE_DOCKER_COMMAND:-""} # See https://github.com/geerlingguy/docker-fedora35-ansible/issues/1
+    command: "/sbin/init"
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     cgroupns_mode: host

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -7,11 +7,6 @@ driver:
 platforms:
   - name: instance
     image: "registry.gitlab.com/aussielunix/ansible/molecule-containers/${MOLECULE_DISTRO:-ubuntu:jammy}"
-#    command: ${MOLECULE_DOCKER_COMMAND:-"/lib/systemd/systemd"}  # See https://github.com/geerlingguy/docker-fedora35-ansible/issues/1
-#    volumes:
-#      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-#      - /var/lib/containerd
-#    cgroupns_mode: host
     privileged: true
     pre_build_image: true
     override_command: false

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -6,7 +6,7 @@ driver:
 platforms:
   - name: instance
     image: ${MOLECULE_DOCKER_IMAGE:-'geerlingguy/docker-ubuntu1804-ansible:latest'}
-    command: ${MOLECULE_DOCKER_COMMAND:-""}
+    command: ${MOLECULE_DOCKER_COMMAND:-"molecule destroy"}
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
     privileged: true

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -13,15 +13,9 @@ platforms:
     cgroupns_mode: host
     privileged: true
     pre_build_image: true
-    env:
-      ANSIBLE_REMOTE_TEMP: /tmp
 provisioner:
   name: ansible
-  env:
-    ANSIBLE_REMOTE_TEMP: /tmp
 verifier:
   name: ansible
   playbooks:
     converge: ${MOLECULE_PLAYBOOK:-converge.yml}
-  env:
-    ANSIBLE_REMOTE_TEMP: /tmp

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -15,7 +15,7 @@ platforms:
     pre_build_image: true
 provisioner:
   name: ansible
-verifier:
-  name: ansible
   playbooks:
     converge: ${MOLECULE_PLAYBOOK:-converge.yml}
+verifier:
+  name: ansible

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -8,7 +8,8 @@ platforms:
     image: ${MOLECULE_DOCKER_IMAGE:-'geerlingguy/docker-ubuntu1804-ansible:latest'}
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
     privileged: true
     pre_build_image: true
 provisioner:

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -6,7 +6,7 @@ driver:
 platforms:
   - name: instance
     image: ${MOLECULE_DOCKER_IMAGE:-'geerlingguy/docker-ubuntu1804-ansible:latest'}
-    command: ${MOLECULE_DOCKER_COMMAND:-"molecule destroy"}
+    command: ${MOLECULE_DOCKER_COMMAND:-""}
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
     privileged: true

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -6,18 +6,23 @@ driver:
   name: docker
 platforms:
   - name: instance
-    image: ${MOLECULE_DOCKER_IMAGE:-'geerlingguy/docker-ubuntu1804-ansible:latest'}
-    # command: ${MOLECULE_DOCKER_COMMAND:-""} # See https://github.com/geerlingguy/docker-fedora35-ansible/issues/1
-    command: "/sbin/init"
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-      - /var/lib/containerd
-    cgroupns_mode: host
+    image: "registry.gitlab.com/aussielunix/ansible/molecule-containers/${MOLECULE_DISTRO:-ubuntu:jammy}"
+#    command: ${MOLECULE_DOCKER_COMMAND:-"/lib/systemd/systemd"}  # See https://github.com/geerlingguy/docker-fedora35-ansible/issues/1
+#    volumes:
+#      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+#      - /var/lib/containerd
+#    cgroupns_mode: host
     privileged: true
     pre_build_image: true
+    override_command: false
+    tmpfs:
+      - /run
+      - /tmp
 provisioner:
   name: ansible
   playbooks:
     converge: ${MOLECULE_PLAYBOOK:-converge.yml}
+  env:
+      ANSIBLE_VERBOSITY: ${MOLECULE_ANSIBLE_VERBOSITY:-0}
 verifier:
   name: ansible

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -11,6 +11,7 @@ platforms:
     command: "/sbin/init"
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
+      - /var/lib/containerd
     cgroupns_mode: host
     privileged: true
     pre_build_image: true

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -13,9 +13,15 @@ platforms:
     cgroupns_mode: host
     privileged: true
     pre_build_image: true
+    env:
+      ANSIBLE_REMOTE_TEMP: /tmp
 provisioner:
   name: ansible
+  env:
+    ANSIBLE_REMOTE_TEMP: /tmp
 verifier:
   name: ansible
   playbooks:
     converge: ${MOLECULE_PLAYBOOK:-converge.yml}
+  env:
+    ANSIBLE_REMOTE_TEMP: /tmp

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -7,7 +7,7 @@ driver:
 platforms:
   - name: instance
     image: ${MOLECULE_DOCKER_IMAGE:-'geerlingguy/docker-ubuntu1804-ansible:latest'}
-    command: ${MOLECULE_DOCKER_COMMAND:-""}
+    # command: ${MOLECULE_DOCKER_COMMAND:-""} # See https://github.com/geerlingguy/docker-fedora35-ansible/issues/1
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     cgroupns_mode: host

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,2 @@
 # pip requirements for testing
-testinfra==3.4.0
-pytest==5.3.2
-docker==3.4.1
-molecule==2.22
+molecule[docker]

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,9 +9,6 @@
 - include_tasks: setup-Ubuntu.yml
   when: ansible_distribution == 'Ubuntu'
 
-- include_tasks: setup-Debian.yml
-  when: ansible_distribution == 'Debian'
-
 - name: Install NGINX
   package:
     name: nginx

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -1,5 +1,0 @@
----
-- name: Add NGINX PPA so we can get a more recent version than with stock apt
-  apt_repository:
-    repo: 'ppa:nginx/stable'
-    codename: trusty

--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -1,6 +1,6 @@
 ---
 
 - name: Ensure nginx is installed.
-  package:
+  yum:
     name: "{{ nginx_package_name }}"
     state: present

--- a/tasks/setup-Ubuntu.yml
+++ b/tasks/setup-Ubuntu.yml
@@ -3,7 +3,7 @@
 - name: Ensure nginx will reinstall if the PPA was just added.
   apt_repository:
     repo: 'ppa:nginx/stable'
-  when: ansible_distribution_version <= '22.04'
+  when: ansible_distribution_version < '22.04'
 
 - name: Ensure nginx will reinstall if the PPA was just added.
   apt:

--- a/tasks/setup-Ubuntu.yml
+++ b/tasks/setup-Ubuntu.yml
@@ -1,13 +1,15 @@
 ---
-
-- name: Ensure nginx will reinstall if the PPA was just added.
+- name: Add external PPA so we can get newer nginx version than what comes stock.
+    This was only really necessary on older Ubuntu versions (e.g. trusty and xenial).
+    Current ubuntu versions ship with a feature-complete nginx.
   apt_repository:
     repo: 'ppa:nginx/stable'
+    codename: '{{ ansible_distribution_release }}'
   when: ansible_distribution_version < '22.04'
+  register: nginx_ppa_add_result
 
-- name: Ensure nginx will reinstall if the PPA was just added.
+- name: Refresh apt cache after adding PPA
   apt:
-    name: nginx
-    state: present
     update_cache: true
-  when: ansible_distribution_version >= '22.04'
+  when: nginx_ppa_add_result is defined
+    and nginx_ppa_add_result.changed

--- a/tasks/setup-Ubuntu.yml
+++ b/tasks/setup-Ubuntu.yml
@@ -3,3 +3,11 @@
 - name: Ensure nginx will reinstall if the PPA was just added.
   apt_repository:
     repo: 'ppa:nginx/stable'
+  when: ansible_distribution_version <= '22.04'
+
+- name: Ensure nginx will reinstall if the PPA was just added.
+  apt:
+    name: nginx
+    state: present
+    update_cache: true
+  when: ansible_distribution_version >= '22.04'


### PR DESCRIPTION
For Ubuntu version greater than 22.04, download nginx from apt